### PR TITLE
Updated error box to fit theme

### DIFF
--- a/tokyonight.rasi
+++ b/tokyonight.rasi
@@ -58,6 +58,11 @@ message {
     border: 0px 1px 1px 1px;
 }
 
+textbox {
+    margin: 10px;
+    color: @kl;
+}
+
 entry, prompt, case-indicator {
     text-font: inherit;
     text-color: inherit;

--- a/tokyonight.rasi
+++ b/tokyonight.rasi
@@ -59,8 +59,12 @@ message {
 }
 
 textbox {
-    margin: 10px;
     color: @kl;
+    padding: 10px;
+    margin: 3px;
+    border: 3px;
+    border-color: @primary;
+    border-radius: 6px;
 }
 
 entry, prompt, case-indicator {

--- a/tokyonight.rasi
+++ b/tokyonight.rasi
@@ -32,8 +32,8 @@ window {
     location: center;
     anchor: center;
     transparency: "screenshot";
-    border-color: @transparent;   
-    border: 0px;
+    border-color: @primary;   
+    border: 3px;
     border-radius: 6px;
     spacing: 0;
     children: [ mainbox ];
@@ -47,24 +47,17 @@ mainbox {
 inputbar {
     color: @kl;
     padding: 11px;
-    border: 3px 3px 2px 3px;
+    border: 0 0 2px 0;
     border-color: @primary;
-    border-radius: 6px 6px 0px 0px;
 }
 
 message {
     padding: 0;
-    border-color: @primary;
-    border: 0px 1px 1px 1px;
 }
 
 textbox {
     color: @kl;
     padding: 10px;
-    margin: 0 0 3px 0;
-    border: 3px;
-    border-color: @primary;
-    border-radius: 6px;
 }
 
 entry, prompt, case-indicator {
@@ -86,9 +79,6 @@ listview {
     padding: 8px;
     lines: 12;
     columns: 1;
-    border: 0px 3px 3px 3px; 
-    border-radius: 0px 0px 6px 6px;
-    border-color: @primary;
     dynamic: false;
 }
 

--- a/tokyonight.rasi
+++ b/tokyonight.rasi
@@ -61,7 +61,7 @@ message {
 textbox {
     color: @kl;
     padding: 10px;
-    margin: 3px;
+    margin: 0 0 3px 0;
     border: 3px;
     border-color: @primary;
     border-radius: 6px;


### PR DESCRIPTION
This pull request simply makes the text color of the error message when nothing can be found match the theme as well as adding padding and a border. I also redid the borders to be global rather than per element. 

Before:
<img width="708" height="68" alt="image" src="https://github.com/user-attachments/assets/c4f7d9fa-65b1-41bb-b916-c9745d86ef57" />

After:
<img width="719" height="97" alt="image" src="https://github.com/user-attachments/assets/b721d903-7940-4cbd-bec7-7d99f2407632" />

